### PR TITLE
docs: translate referencias-curadas to English

### DIFF
--- a/design-library/referencias-curadas.md
+++ b/design-library/referencias-curadas.md
@@ -1,12 +1,12 @@
-# Biblioteca de Referências de Design - Jobim
+# Design Reference Library - Jobim
 
-> Curadoria de 120+ sites do onepagelove.com organizados por categoria
+> Curated collection of 120+ sites from onepagelove.com organized by category
 
 ---
 
 ## Landing Pages (32 sites)
 
-| # | Nome | URL OnePageLove | Site Original |
+| # | Name | URL OnePageLove | Original Site |
 |---|------|-----------------|---------------|
 | 1 | EyeDrop | https://onepagelove.com/eyedrop | - |
 | 2 | Interface Craft | https://onepagelove.com/interface-craft | - |
@@ -45,7 +45,7 @@
 
 ## SaaS (24 sites)
 
-| # | Nome | URL OnePageLove | Site Original |
+| # | Name | URL OnePageLove | Original Site |
 |---|------|-----------------|---------------|
 | 1 | Outseta | https://onepagelove.com/outseta-memberstack-alternative | outseta.com |
 | 2 | Monologue | https://onepagelove.com/monologue | monologue.to |


### PR DESCRIPTION
This PR translates the Portuguese content in `design-library/referencias-curadas.md` into English.

Changes made:

- Translated the document title and description into English
- Updated table headers from Portuguese (Nome) to English (Name)
- Preserved all existing links, structure, and formatting

This helps make the documentation accessible to a wider open-source community.
